### PR TITLE
Fixes #30 Different welcome page for admin and employee

### DIFF
--- a/src/App/IntroPage/IntropageController.java
+++ b/src/App/IntroPage/IntropageController.java
@@ -9,6 +9,7 @@ import java.time.LocalDate;
 import java.util.ResourceBundle;
 import App.Connect;
 import App.ProjectDetail.ProjectDetailController;
+import App.SearchProject.SearchProject;
 import com.jfoenix.controls.JFXButton;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
@@ -33,15 +34,57 @@ public class IntropageController implements Initializable {
     @FXML
     private Accordion accordion;
 
+
+    public String getUserRole() {
+        return userRole;
+    }
+
+    public void setUserRole(String userRole) {
+        this.userRole = userRole;
+    }
+
+    private String userRole;
+
+    public int getEmployeeId() {
+        return employeeId;
+    }
+
+    public void setEmployeeId(int employeeId) {
+        this.employeeId = employeeId;
+        System.out.println(employeeId);
+    }
+
+    private int employeeId;
+
     // When user clicks on Add new Project button
     @FXML
     private void ProjectDetail(ActionEvent event) throws IOException {
         if(event.getSource() == btnProjectDetail) {
-            stage = (Stage) btnProjectDetail.getScene().getWindow();
-            root = FXMLLoader.load(getClass().getResource("../ProjectDetail/projectdetail.fxml"));
-            Scene scene = new Scene(root);
-            stage.setScene(scene);
-            stage.show();
+            if(getUserRole().matches("ADMIN_AUTH")) {
+                FXMLLoader Loader = new FXMLLoader();
+
+                Loader.setLocation(getClass().getResource("../ProjectDetail/projectdetail.fxml"));
+
+                try {
+                    Loader.load();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+
+                ProjectDetailController projectDetailController = Loader.getController();
+                projectDetailController.setUserRole(getUserRole());
+                if (getUserRole().matches("EMPLOYEE_AUTH")) {
+                    projectDetailController.setEmployeeId(getEmployeeId());
+                }
+
+                Parent p = Loader.getRoot();
+                stage = (Stage) allproject.getScene().getWindow();
+                Scene scene = new Scene(p);
+                stage.setScene(scene);
+                stage.show();
+            } else {
+                System.out.println("Employee profile needed");
+            }
         }
     }
 
@@ -59,6 +102,13 @@ public class IntropageController implements Initializable {
                 e.printStackTrace();
             }
 
+            IntropageController intropageController = Loader.getController();
+            intropageController.setUserRole(getUserRole());
+            if(getUserRole().matches("EMPLOYEE_AUTH")) {
+                intropageController.setEmployeeId(getEmployeeId());
+            }
+            intropageController.initilizePorjects(getUserRole());
+
             Parent p = Loader.getRoot();
             stage = (Stage) allproject.getScene().getWindow();
             Scene scene = new Scene(p);
@@ -75,11 +125,18 @@ public class IntropageController implements Initializable {
 
             Loader.setLocation(getClass().getResource("../SearchProject/searchproject.fxml"));
 
-            try{
+            try {
                 Loader.load();
             } catch (Exception e){
                 e.printStackTrace();
             }
+
+            SearchProject searchProject = Loader.getController();
+            searchProject.setUserRole(getUserRole());
+            if(getUserRole().matches("EMPLOYEE_AUTH")){
+                searchProject.setEmployeeId(getEmployeeId());
+            }
+            searchProject.initializeSearchProject();
 
             Parent p = Loader.getRoot();
             stage = (Stage) searchproject.getScene().getWindow();
@@ -89,8 +146,18 @@ public class IntropageController implements Initializable {
         }
     }
 
-    @Override
-    public void initialize(URL url, ResourceBundle rb) {
+    public void initilizePorjects(String userRole){
+        FXMLLoader Loader = new FXMLLoader();
+        String sql;
+
+        if(userRole.matches("ADMIN_AUTH")) {
+            sql  = "SELECT * FROM PROJECT_INFO";
+        }
+        else {
+            sql = "SELECT distinct PROJECT_INFO.id, project_name, start_date, end_date, estimated_time FROM PROJECT_INFO, PROJECT_TASK WHERE PROJECT_INFO.id = PROJECT_TASK.id AND assigned = (SELECT name FROM EMPLOYEE WHERE EMPLOYEE.id="+getEmployeeId()+")";
+            btnProjectDetail.setText("Profile");
+        }
+
 
         try {
             Connect connect = new Connect();
@@ -98,9 +165,7 @@ public class IntropageController implements Initializable {
 
             Statement statement = connection.createStatement();
 
-            // * = id, project_name, start_date, end_date, estimated_time
-            // All above information are taken from project_info table
-            ResultSet rs = statement.executeQuery("SELECT * FROM PROJECT_INFO");
+            ResultSet rs = statement.executeQuery(sql);
 
             while (rs.next()) {
 
@@ -134,39 +199,45 @@ public class IntropageController implements Initializable {
                 accordion.getPanes().add(titledpane);
 
                 showporject.setOnAction((event) -> {
-                    FXMLLoader Loader = new FXMLLoader();
+
                     Loader.setLocation(getClass().getResource("../ProjectDetail/projectdetail.fxml"));
 
-                    try{
+                    try {
                         Loader.load();
-                    } catch (Exception e){
+                    } catch (Exception e) {
                         e.printStackTrace();
                     }
 
                     // A ProjectDetailController object is created
                     // to send information of the project detail page
-                    ProjectDetailController display = Loader.getController();
+                    ProjectDetailController projectDetailController = Loader.getController();
 
-                    display.setProjectID(id);
-                    display.getProjectID().setDisable(true);
-                    display.setProjectName(projectname);
-                    display.getProjectName().setEditable(false);
+                    projectDetailController.setProjectID(id);
+                    projectDetailController.getProjectID().setDisable(true);
+                    projectDetailController.setProjectName(projectname);
+                    projectDetailController.getProjectName().setEditable(false);
 
                     // startdate is a string
-                    display.setStart_date(LocalDate.parse(startdate));
-                    display.getStart_date().setDisable(true);
+                    projectDetailController.setStart_date(LocalDate.parse(startdate));
+                    projectDetailController.getStart_date().setDisable(true);
 
                     // enddate is a string
-                    display.setEnd_date(LocalDate.parse(enddate));
+                    projectDetailController.setEnd_date(LocalDate.parse(enddate));
 
                     // Note: for LocalDate setEditable() method doesn't work in Jfonix.
                     // Ref: https://github.com/jfoenixadmin/JFoenix/issues/708
-                    display.getEnd_date().setDisable(true);
-                    display.setEsti_time(estitime);
-                    display.getEsti_time().setEditable(false);
+                    projectDetailController.getEnd_date().setDisable(true);
+                    projectDetailController.setEsti_time(estitime);
+                    projectDetailController.getEsti_time().setEditable(false);
 
                     // Calling getTableData() method to fill the table data from database following the above information
-                    display.getTableData();
+                    projectDetailController.getTableData();
+
+                    projectDetailController.setUserRole(getUserRole());
+                    if(getUserRole().matches("EMPLOYEE_AUTH")) {
+                        projectDetailController.setEmployeeId(getEmployeeId());
+                    }
+                    projectDetailController.initialProjectDetail();
 
                     Parent p = Loader.getRoot();
                     stage = (Stage) showporject.getScene().getWindow();
@@ -180,5 +251,11 @@ public class IntropageController implements Initializable {
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+
+    @Override
+    public void initialize(URL url, ResourceBundle rb) {
+
     }
 }

--- a/src/App/LoginController.java
+++ b/src/App/LoginController.java
@@ -20,6 +20,7 @@ import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.RadioButton;
+import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 
 public class LoginController implements Initializable {
@@ -38,7 +39,17 @@ public class LoginController implements Initializable {
     public RadioButton adminToggle;
     public RadioButton employeeToggle;
 
-    private String userRole;
+    public int getEmployeeId() {
+        return EmployeeId;
+    }
+
+    public void setEmployeeId(int employeeId) {
+        EmployeeId = employeeId;
+    }
+
+    private int EmployeeId;
+
+    public String userRole;
 
     public String getUserRole() {
         return userRole;
@@ -46,25 +57,71 @@ public class LoginController implements Initializable {
 
     @FXML
     private void Login(ActionEvent actionEvent) throws IOException {
-        Connect connect = new Connect();
-        Connection connection=connect.getConnection();
 
         if(!employeeToggle.isSelected() && !adminToggle.isSelected()){
             isConnected.setText("Select Admin or Employee from above");
             return;
         }
 
+        FXMLLoader Loader = new FXMLLoader();
+
+//        if(userRole.matches("EMPLOYEE_AUTH")){
+//            try {
+//                Connect connect = new Connect();
+//                Connection connection=connect.getConnection();
+//                Statement statement = connection.createStatement();
+//                String sql = "SELECT id FROM project_task WHERE id = "+getProjectID().getText();
+//                ResultSet rs = statement.executeQuery(sql);
+//
+//                while (rs.next()) {
+//                    String TaskName = rs.getString("task_name");
+//                    java.util.Date StartDate =  rs.getDate("task_start_date");
+//                    java.util.Date EndDate = rs.getDate("task_end_date");
+//                    String TaskColor = rs.getString("color");
+//
+//                    TaskColors.add(toRGBCode(Color.valueOf(TaskColor)));
+//                    TaskNames.add(TaskName);
+//                    startDates.add(StartDate);
+//                    endDates.add(EndDate);
+//                    ++count;
+//                }
+//                statement.close();
+//                connection.close();
+//            }
+//            catch (Exception e){
+//                e.printStackTrace();
+//            }
+//        }
+
         try {
+            Connect connect = new Connect();
+            Connection connection=connect.getConnection();
             Statement statement = connection.createStatement();
             String sql = "SELECT * FROM "+userRole+" WHERE username = '" + username.getText() + "' AND password = '" + password.getText() + "';";
             ResultSet resultSet = statement.executeQuery(sql);
-
             // Resultset contains all the username and password
             // if the username and password from database matches only then intropage loads
             if (resultSet.next()) {
-                stage = (Stage) loginbutton.getScene().getWindow();
-                root = FXMLLoader.load(getClass().getResource("IntroPage/intropage.fxml"));
-                Scene scene = new Scene(root);
+                //load up OTHER FXML document
+                int employeeid = resultSet.getInt("id");
+                Loader.setLocation(getClass().getResource("IntroPage/intropage.fxml"));
+                try{
+                    Loader.load();
+                } catch (Exception e){
+                    e.printStackTrace();
+                }
+
+                IntropageController intropageController = Loader.getController();
+                intropageController.setUserRole(getUserRole());
+                if(userRole.matches("EMPLOYEE_AUTH")){
+                    intropageController.setEmployeeId(employeeid);
+                }
+
+                intropageController.initilizePorjects(getUserRole());
+
+                Parent p = Loader.getRoot();
+                stage = (Stage) adminToggle.getScene().getWindow();
+                Scene scene = new Scene(p);
                 stage.setScene(scene);
                 stage.show();
             } else {

--- a/src/App/ProjectDetail/ProjectDetailController.java
+++ b/src/App/ProjectDetail/ProjectDetailController.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.ArrayList;
 import java.util.ResourceBundle;
 
+import App.IntroPage.IntropageController;
+import App.SearchProject.SearchProject;
 import App.chart.DateAxis;
 import App.chart.GanttChartController;
 import App.chart.GanttChartController.ExtraData;
@@ -57,6 +59,26 @@ public class ProjectDetailController implements Initializable {
     final private String NO_START_DATE_ERROR = "Start date cannot be empty";
     final private String INVALID_END_DATE = "End date must be equal or greater than start date";
 
+    public String getUserRole() {
+        return userRole;
+    }
+
+    public void setUserRole(String userRole) {
+        this.userRole = userRole;
+    }
+
+    private String userRole;
+
+    public int getEmployeeId() {
+        return employeeId;
+    }
+
+    public void setEmployeeId(int employeeId) {
+        this.employeeId = employeeId;
+    }
+
+    private int employeeId;
+
     @FXML
     JFXTextField ProjectID;
     @FXML
@@ -85,7 +107,6 @@ public class ProjectDetailController implements Initializable {
     public JFXTextField getProjectName() {
         return ProjectName;
     }
-
 
     public void setProjectID(String projectID) {
         ProjectID.setText(projectID);
@@ -392,6 +413,14 @@ public class ProjectDetailController implements Initializable {
                 e.printStackTrace();
             }
 
+            IntropageController intropageController = Loader.getController();
+            intropageController.setUserRole(getUserRole());
+            System.out.println(getUserRole());
+            if(getUserRole().matches("EMPLOYEE_AUTH")){
+                intropageController.setEmployeeId(getEmployeeId());
+            }
+            intropageController.initilizePorjects(getUserRole());
+
             Parent p = Loader.getRoot();
             Scene scene = new Scene(p);
             stage.setScene(scene);
@@ -402,22 +431,31 @@ public class ProjectDetailController implements Initializable {
 
     public void ProjectDetail(ActionEvent event) {
         if(event.getSource() == btnProjectDetail) {
-            FXMLLoader Loader = new FXMLLoader();
+            if(getUserRole().matches("ADMIN_AUTH")) {
+                FXMLLoader Loader = new FXMLLoader();
 
-            Loader.setLocation(getClass().getResource("projectdetail.fxml"));
+                Loader.setLocation(getClass().getResource("../ProjectDetail/projectdetail.fxml"));
 
-            try{
-                Loader.load();
-            } catch (Exception e){
-                e.printStackTrace();
+                try {
+                    Loader.load();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+
+                ProjectDetailController projectDetailController = Loader.getController();
+                projectDetailController.setUserRole(getUserRole());
+                if (getUserRole().matches("EMPLOYEE_AUTH")) {
+                    projectDetailController.setEmployeeId(getEmployeeId());
+                }
+
+                Parent p = Loader.getRoot();
+                stage = (Stage) allproject.getScene().getWindow();
+                Scene scene = new Scene(p);
+                stage.setScene(scene);
+                stage.show();
+            } else {
+                System.out.println("Employee profile needed");
             }
-
-
-            Parent p = Loader.getRoot();
-            stage = (Stage) btnProjectDetail.getScene().getWindow();
-            Scene scene = new Scene(p);
-            stage.setScene(scene);
-            stage.show();
         }
     }
 
@@ -431,6 +469,12 @@ public class ProjectDetailController implements Initializable {
                 Loader.load();
             } catch (Exception e){
                 e.printStackTrace();
+            }
+
+            SearchProject searchProject = Loader.getController();
+            searchProject.setUserRole(getUserRole());
+            if(getUserRole().matches("EMPLOYEE_AUTH")){
+                searchProject.setEmployeeId(getEmployeeId());
             }
 
             Parent p = Loader.getRoot();
@@ -545,5 +589,11 @@ public class ProjectDetailController implements Initializable {
                 (int)( color.getRed() * 255 ),
                 (int)( color.getGreen() * 255 ),
                 (int)( color.getBlue() * 255 ) );
+    }
+
+    public void initialProjectDetail(){
+        if(getUserRole().matches("EMPLOYEE_AUTH")){
+            btnProjectDetail.setText("profile");
+        }
     }
 }

--- a/src/App/SearchProject/SearchProject.java
+++ b/src/App/SearchProject/SearchProject.java
@@ -1,6 +1,7 @@
 package App.SearchProject;
 
 import App.Connect;
+import App.IntroPage.IntropageController;
 import App.ProjectDetail.ProjectDetailController;
 import com.jfoenix.controls.JFXButton;
 import com.jfoenix.controls.JFXTextField;
@@ -18,6 +19,25 @@ import java.time.LocalDate;
 public class SearchProject {
 
     Stage stage;
+
+    public String getUserRole() {
+        return userRole;
+    }
+
+    public void setUserRole(String userRole) {
+        this.userRole = userRole;
+    }
+
+    public int getEmployeeId() {
+        return EmployeeId;
+    }
+
+    public void setEmployeeId(int employeeId) {
+        EmployeeId = employeeId;
+    }
+
+    private String userRole;
+    private int EmployeeId;
 
     public Label isprojectfound;
     public JFXTextField inputprojectid;
@@ -44,6 +64,13 @@ public class SearchProject {
                 e.printStackTrace();
             }
 
+            IntropageController intropageController = Loader.getController();
+            intropageController.setUserRole(getUserRole());
+            if(getUserRole().matches("EMPLOYEE_AUTH")) {
+                intropageController.setEmployeeId(getEmployeeId());
+            }
+            intropageController.initilizePorjects(getUserRole());
+
             Parent p = Loader.getRoot();
             Scene scene = new Scene(p);
             stage.setScene(scene);
@@ -52,22 +79,32 @@ public class SearchProject {
     }
 
     public void ProjectDetail(ActionEvent event) {
-        if (event.getSource() == btnProjectDetail) {
-            FXMLLoader Loader = new FXMLLoader();
+        if(event.getSource() == btnProjectDetail) {
+            if(getUserRole().matches("ADMIN_AUTH")) {
+                FXMLLoader Loader = new FXMLLoader();
 
-            Loader.setLocation(getClass().getResource("../ProjectDetail/projectdetail.fxml"));
+                Loader.setLocation(getClass().getResource("../ProjectDetail/projectdetail.fxml"));
 
-            try {
-                Loader.load();
-            } catch (Exception e) {
-                e.printStackTrace();
+                try {
+                    Loader.load();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+
+                ProjectDetailController projectDetailController = Loader.getController();
+                projectDetailController.setUserRole(getUserRole());
+                if (getUserRole().matches("EMPLOYEE_AUTH")) {
+                    projectDetailController.setEmployeeId(getEmployeeId());
+                }
+
+                Parent p = Loader.getRoot();
+                stage = (Stage) allproject.getScene().getWindow();
+                Scene scene = new Scene(p);
+                stage.setScene(scene);
+                stage.show();
+            } else {
+                System.out.println("Employee profile needed");
             }
-
-            Parent p = Loader.getRoot();
-            stage = (Stage) btnProjectDetail.getScene().getWindow();
-            Scene scene = new Scene(p);
-            stage.setScene(scene);
-            stage.show();
         }
     }
 
@@ -122,6 +159,12 @@ public class SearchProject {
             else {
                 isprojectfound.setText("Project ID has not found!");
             }
+        }
+    }
+
+    public void initializeSearchProject(){
+        if(getUserRole().matches("EMPLOYEE_AUTH")) {
+            btnProjectDetail.setText("Profile");
         }
     }
 }


### PR DESCRIPTION
Fixes #30 
Now Admin and Employee get to see different welcome page after they log in.
### Changes in top menu:
Employee welcome page have All projects, Profile, Search project
Admin welcome page have All projects, Add new project, Search project

### Changes in Existing projects section:
Admin can see all projects that has been created.
Employee can see only projects where he/she has been assigned for work.

## Admin welcome page 
<img width="628" alt="Screenshot 2019-08-31 at 4 49 01 PM" src="https://user-images.githubusercontent.com/8364578/64062946-7de13e00-cc0f-11e9-9695-842cb1a03c5c.png">

## Employee welcome page 
<img width="609" alt="Screenshot 2019-08-31 at 4 49 32 PM" src="https://user-images.githubusercontent.com/8364578/64062953-90f40e00-cc0f-11e9-8eb8-3ab86143b1fa.png">

