### PR TITLE
fixes #34 : Redesign Project Details page for Employees

### DIFF
--- a/src/App/Login/LoginController.java
+++ b/src/App/Login/LoginController.java
@@ -125,13 +125,13 @@ public class LoginController implements Initializable {
                     ProjectSummaryController projectSummaryController = Loader.getController();
                     projectSummaryController.setUserRole(getUserRole());
                     projectSummaryController.setEmployeeId(employeeid);
-
                     projectSummaryController.initilizePorjects(getUserRole());
 
                     Parent p = Loader.getRoot();
                     stage = (Stage) adminToggle.getScene().getWindow();
                     Scene scene = new Scene(p);
                     stage.setScene(scene);
+                    stage.centerOnScreen();
                     stage.show();
                 } else {
                     // If username & password doesn't match

--- a/src/App/ProjectDetail/ProjectDetailController.java
+++ b/src/App/ProjectDetail/ProjectDetailController.java
@@ -331,7 +331,8 @@ public class ProjectDetailController implements Initializable {
 
         String sql = "UPDATE project_task SET progress= '"+task.getTaskProgress()+"' WHERE task_name='"+task.getTaskName()+"'";
 
-        Statement statement = connection.prepareStatement(sql);
+        Statement statement = connection.createStatement();
+
         statement.executeUpdate(sql);
 
         statement.close();
@@ -622,6 +623,17 @@ public class ProjectDetailController implements Initializable {
             Scene scene = new Scene(p);
             stage.setScene(scene);
             stage.show();
+        }
+    }
+
+    public void ifUserIsEmployee(String userRole){
+        if(userRole.matches("EMPLOYEE_AUTH")){
+            btnAddTask.setDisable(true);
+            DeleteTaskButton.setDisable(true);
+            btnProjectDetail.setDisable(true);
+            homeBackBtn.setDisable(true); // Remove it when home page for employee is done.
+            searchproject.setDisable(true); // Remove it when search project page for employee is done.
+            tableview.setEditable(false);
         }
     }
 }

--- a/src/App/ProjectSummary/ProjectSummaryController.java
+++ b/src/App/ProjectSummary/ProjectSummaryController.java
@@ -169,7 +169,8 @@ public class ProjectSummaryController implements Initializable {
         else {
             sql = "SELECT distinct PROJECT_INFO.id, project_name, start_date, end_date, estimated_time FROM PROJECT_INFO, PROJECT_TASK WHERE PROJECT_INFO.id = PROJECT_TASK.id AND assigned = (SELECT name FROM EMPLOYEE WHERE EMPLOYEE.id="+getEmployeeId()+")";
             btnProjectDetail.setDisable(true);
-            homeBackBtn.setDisable(true); //Enable it and link to Employee Intro page once it is made
+            homeBackBtn.setDisable(true); // Remove it when home page for employee is done.
+            searchproject.setDisable(true); // Remove it when search project page for employee is done.
         }
 
 
@@ -254,6 +255,7 @@ public class ProjectSummaryController implements Initializable {
                     projectDetailController.setUserRole(getUserRole());
                     if(getUserRole().matches("EMPLOYEE_AUTH")) {
                         projectDetailController.setEmployeeId(getEmployeeId());
+                        projectDetailController.ifUserIsEmployee(getUserRole());
                     }
 
                     Parent p = Loader.getRoot();


### PR DESCRIPTION
Fixes #34 .

- [x] Employee can not add new task to project. Hence remove `Add Task` button from Employee.
- [x] Employee can not delete existing tasks. Hence remove `Delete Task` button from Employee.
- [x] Employee can not edit progress in tasks table. Hence disable that functionality for employee.
